### PR TITLE
fix: Map zero to zero when scaling

### DIFF
--- a/ros2_ws/src/remote_pi/remote_pi/remote.py
+++ b/ros2_ws/src/remote_pi/remote_pi/remote.py
@@ -71,7 +71,9 @@ class SerialPublisher(Node):
 
     # scale values from [-512,511] to [-1,1]
     def scale(self, m):
-        return (m+512)/(511.5)-1
+        if (m==0):
+            return 0
+        return round((m+512)/(511.5)-1, 4)
 
     def run(self):
         self.start_arduino()


### PR DESCRIPTION
When scaling from [-512,511] to [-1,1] map 0 in the first range to 0 in the second one to avoid unwanted movement when joysticks are in default position.